### PR TITLE
Ensuring that bundled get initialized properly. Fix for issue https://github.com/twilio/wiztowar/issues/2

### DIFF
--- a/src/main/java/com/twilio/wiztowar/DWAdapter.java
+++ b/src/main/java/com/twilio/wiztowar/DWAdapter.java
@@ -115,6 +115,8 @@ public abstract class DWAdapter<T extends Configuration> extends Application {
 
                 environment.start();
 
+                bootstrap.runWithBundles(configuration, environment); //Fix for issue https://github.com/twilio/wiztowar/issues/2
+
                 dwService.run(configuration, environment);
                 addHealthChecks(environment);
                 final ServletContext servletContext = ServletContextCallback.getServletContext();


### PR DESCRIPTION
This is a fix for issue https://github.com/twilio/wiztowar/issues/2. In order for the bundles to get initialized properly, the runWithBundles method has to be invoked on the bootstrap instance
